### PR TITLE
Update UI_handler.py

### DIFF
--- a/SHG_MAIN.py
+++ b/SHG_MAIN.py
@@ -184,7 +184,7 @@ def handle_folder(options):
                 break
             time.sleep(0.1)
             if not prev is None:
-                window['_prev_img'].update(data=UI_handler.get_img_data(prev, maxsize=(600,600), first=True))
+                window['_prev_img'].update(data=UI_handler.get_img_data(prev, maxsize=(600,600), first=True, convertI=True)) # use convertI to propertly handle variety of image formats (8-bit etc.)
                 window['last'].update('Last: ' + prev)
             window.perform_long_operation(lambda : time.sleep(1), '-END SLEEP-')
 

--- a/UI_handler.py
+++ b/UI_handler.py
@@ -119,7 +119,7 @@ def get_img_data(f, maxsize=(30, 18), first=False):
     """Generate image data using PIL
     """
     try:
-        img = Image.open(f)
+        img = Image.open(f).convert('I')
         img.thumbnail(maxsize)
         if first:                     # tkinter is inactive the first time
             bio = io.BytesIO()

--- a/UI_handler.py
+++ b/UI_handler.py
@@ -115,11 +115,13 @@ def read_langs():
 # ------------------------------------------------------------------------------
 
 
-def get_img_data(f, maxsize=(30, 18), first=False):
+def get_img_data(f, maxsize=(30, 18), first=False, convertI=False):
     """Generate image data using PIL
     """
     try:
-        img = Image.open(f).convert('I')
+        img = Image.open(f)
+        if convertI:
+            img = img.convert('I')
         img.thumbnail(maxsize)
         if first:                     # tkinter is inactive the first time
             bio = io.BytesIO()


### PR DESCRIPTION
add convert('I') to avoid run error (PIL "ValueError: image has wrong mode") when process 16-bit serfile in 'folder input mode' with PIL.   

But use convert('I') will cause language flags become mono, also I'm not sure if this convert will cause 16-bit serfile to be processed in 8-bit mode ? please confirm it . 
<img width="159" height="60" alt="m" src="https://github.com/user-attachments/assets/660bc9be-a1b9-491b-98ff-c202aa0d35a3" />

If use  convert('RGB'), the language flags will remain in color mode , but the preview image in 'folder inout mode' will over expose, althought the result images are good in expose.

